### PR TITLE
Fix for folders_to_skip and names_to_skip

### DIFF
--- a/pygount/analysis.py
+++ b/pygount/analysis.py
@@ -127,11 +127,16 @@ for oracle_suffix in ("pck", "pkb", "pks", "pls"):
 
 
 class SourceScanner:
-    def __init__(self, source_patterns, suffixes="*"):
+    def __init__(self, 
+                 source_patterns, 
+                 suffixes='*',
+                 folders_to_skip=pygount.common.regexes_from(DEFAULT_FOLDER_PATTERNS_TO_SKIP_TEXT),
+                 name_to_skip=pygount.common.regexes_from(DEFAULT_NAME_PATTERNS_TO_SKIP_TEXT)
+                 ):
         self._source_patterns = source_patterns
         self._suffixes = pygount.common.regexes_from(suffixes)
-        self._folder_regexps_to_skip = pygount.common.regexes_from(DEFAULT_FOLDER_PATTERNS_TO_SKIP_TEXT)
-        self._name_regexps_to_skip = pygount.common.regexes_from(DEFAULT_NAME_PATTERNS_TO_SKIP_TEXT)
+        self._folder_regexps_to_skip = folders_to_skip
+        self._name_regexps_to_skip = name_to_skip
 
     @property
     def source_patterns(self):

--- a/pygount/command.py
+++ b/pygount/command.py
@@ -311,7 +311,10 @@ class Command:
 
     def execute(self):
         _log.setLevel(logging.INFO if self.is_verbose else logging.WARNING)
-        source_scanner = pygount.analysis.SourceScanner(self.source_patterns, self.suffixes)
+        source_scanner = pygount.analysis.SourceScanner(self.source_patterns, 
+                                                        self.suffixes, 
+                                                        self.folders_to_skip, 
+                                                        self.names_to_skip)
         source_paths_and_groups_to_analyze = list(source_scanner.source_paths())
         duplicate_pool = pygount.analysis.DuplicatePool() if not self.has_duplicates else None
 


### PR DESCRIPTION
Fix for folders_to_skip and names_to_skip by parsing them correctly to
SourceScanner. There might be a more elegant way of fixing this, but
it was the intuitive way I found.

Fix for Issue: Problems with --folders-to-skip #17