### PR TITLE
Fix analysis with FIPS mode

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -153,7 +153,7 @@ to be counted again.
 For two files to be considered duplicates the following conditions must be met:
 
 #. Both files have the same size.
-#. Both files have the same `MD5 <https://en.wikipedia.org/wiki/MD5>`_
+#. Both files have the same `SHA-256 <https://en.wikipedia.org/wiki/SHA-2>`_
    hashcode.
 
 This allows for an efficient detection with a very small possibility for false

--- a/pygount/analysis.py
+++ b/pygount/analysis.py
@@ -155,13 +155,13 @@ class DuplicatePool:
     @staticmethod
     def _hash_for(path_to_hash):
         buffer_size = 1024 * 1024
-        sha1_hash = hashlib.sha1()
+        sha256_hash = hashlib.sha256()
         with open(path_to_hash, "rb", buffer_size) as file_to_hash:
             data = file_to_hash.read(buffer_size)
             while len(data) >= 1:
-                sha1_hash.update(data)
+                sha256_hash.update(data)
                 data = file_to_hash.read(buffer_size)
-        return sha1_hash.digest()
+        return sha256_hash.digest()
 
     def duplicate_path(self, source_path: str) -> Optional[str]:
         """

--- a/pygount/analysis.py
+++ b/pygount/analysis.py
@@ -155,13 +155,13 @@ class DuplicatePool:
     @staticmethod
     def _hash_for(path_to_hash):
         buffer_size = 1024 * 1024
-        md5_hash = hashlib.sha1()
+        sha1_hash = hashlib.sha1()
         with open(path_to_hash, "rb", buffer_size) as file_to_hash:
             data = file_to_hash.read(buffer_size)
             while len(data) >= 1:
-                md5_hash.update(data)
+                sha1_hash.update(data)
                 data = file_to_hash.read(buffer_size)
-        return md5_hash.digest()
+        return sha1_hash.digest()
 
     def duplicate_path(self, source_path: str) -> Optional[str]:
         """

--- a/pygount/analysis.py
+++ b/pygount/analysis.py
@@ -155,7 +155,7 @@ class DuplicatePool:
     @staticmethod
     def _hash_for(path_to_hash):
         buffer_size = 1024 * 1024
-        md5_hash = hashlib.md5(usedforsecurity=False)
+        md5_hash = hashlib.sha1()
         with open(path_to_hash, "rb", buffer_size) as file_to_hash:
             data = file_to_hash.read(buffer_size)
             while len(data) >= 1:

--- a/pygount/analysis.py
+++ b/pygount/analysis.py
@@ -155,7 +155,7 @@ class DuplicatePool:
     @staticmethod
     def _hash_for(path_to_hash):
         buffer_size = 1024 * 1024
-        md5_hash = hashlib.md5()
+        md5_hash = hashlib.md5(usedforsecurity=False)
         with open(path_to_hash, "rb", buffer_size) as file_to_hash:
             data = file_to_hash.read(buffer_size)
             while len(data) >= 1:


### PR DESCRIPTION
With FIPS mode the following error is thrown.
`ValueError: [digital envelope routines: EVP_DigestInit_ex] disabled for FIPS`