### PR TITLE
Allow alternative ways of classifying languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ You can pass a specific revision at the end of the remote URL:
 $ pygount --format=summary https://github.com/roskakori/pygount.git/v1.5.1
 ```
 
+You can tell Pygount to classify by file extension rather than Pygments language
+detection:
+
+```bash
+$ pygount --classify=extension https://github.com/roskakori/pygount.git/v1.5.1
+```
+
+
+
 This example results in the following summary output:
 
 ```

--- a/pygount/analysis.py
+++ b/pygount/analysis.py
@@ -331,7 +331,10 @@ class SourceAnalysis:
             if source_size == 0:
                 _log.info("%s: is empty", source_path)
                 result = SourceAnalysis.from_state(
-                    source_path, group, SourceState.empty
+                    source_path,
+                    group,
+                    SourceState.empty,
+                    language_field_formatter=language_field_formatter,
                 )
             elif is_binary_file(source_path):
                 _log.info("%s: is binary", source_path)
@@ -344,7 +347,10 @@ class SourceAnalysis:
             elif not has_lexer(source_path):
                 _log.info("%s: unknown language", source_path)
                 result = SourceAnalysis.from_state(
-                    source_path, group, SourceState.unknown
+                    source_path,
+                    group,
+                    SourceState.unknown,
+                    language_field_formatter=language_field_formatter,
                 )
         if duplicate_pool is not None:
             duplicate_path = duplicate_pool.duplicate_path(source_path)

--- a/pygount/language_classification.py
+++ b/pygount/language_classification.py
@@ -1,0 +1,22 @@
+import os
+import re
+
+
+_BASE_LANGUAGE_REGEX = re.compile(r"^(?P<base_language>[^+]+)\+[^+].*$")
+
+
+def base_language(language: str) -> str:
+    base_language_match = _BASE_LANGUAGE_REGEX.match(language)
+    return (
+        language
+        if base_language_match is None
+        else base_language_match.group("base_language")
+    )
+
+
+def extension_classifier(filename: str, pygments_class: str) -> str:
+    return "." + os.path.basename(filename).split(".", 1)[-1]
+
+
+def pygments_classifier(filename: str, pygments_class: str) -> str:
+    return pygments_class


### PR DESCRIPTION
This is in response to the issues in #105.  This adds a --classify=extension feature to classify by file extension,
while being extensible to allow for other schemes, like merging sublanguages.

Unfortunately, I was not able to get the pre-commit hooks to run, so this is just a work in progress, submitted now for review and discussion to make sure I'm generally on the right track.

For some reason on my system certain hooks refuse to install, and I haven't had time to debug the issue, hopefully the new Ubuntu fixes this and I can revisit this.
