### PR TITLE
#113 Remove temporary directory in the output of a git analysis

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,8 @@ Version 1.8.1, 2024-07-xx
   `#157 <https://github.com/roskakori/pygount/issues/157>`_).
 * Development: Change default branch to main (issue
   `#160 <https://github.com/roskakori/pygount/issues/160>`_).
+* Remove temporary directory in the output of a git analysis (contributed by
+  Isabel Beckenbach, issue `#113 <https://github.com/roskakori/pygount/issues/113>`_)
 
 Version 1.8.0, 2024-05-13
 

--- a/pygount/command.py
+++ b/pygount/command.py
@@ -353,16 +353,17 @@ class Command:
                 disable=not writer.has_to_track_progress, transient=True
             ) as progress:
                 try:
-                    for source_path, group in progress.track(source_paths_and_groups_to_analyze):
+                    for path_data in progress.track(source_paths_and_groups_to_analyze):
                         writer.add(
                             pygount.analysis.SourceAnalysis.from_file(
-                                source_path,
-                                group,
+                                path_data.source_path,
+                                path_data.group,
                                 self.default_encoding,
                                 self.fallback_encoding,
                                 generated_regexes=self._generated_regexs,
                                 duplicate_pool=duplicate_pool,
                                 merge_embedded_language=self.has_to_merge_embedded_languages,
+                                tmp_dir=path_data.tmp_dir,
                             )
                         )
                 finally:

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -47,8 +47,8 @@ class SourceScannerTest(TempFolderTest):
         scanner = analysis.SourceScanner([PYGOUNT_SOURCE_FOLDER], "py")
         actual_paths = list(scanner.source_paths())
         assert actual_paths != []
-        for python_path, _ in actual_paths:
-            actual_suffix = os.path.splitext(python_path)[1]
+        for path_data in actual_paths:
+            actual_suffix = os.path.splitext(path_data.source_path)[1]
             assert actual_suffix == ".py"
 
     def test_can_skip_dot_folder(self):
@@ -61,15 +61,15 @@ class SourceScannerTest(TempFolderTest):
         self.create_temp_file(relative_path_to_skip, "skip = 2", do_create_folder=True)
 
         scanner = analysis.SourceScanner([project_folder])
-        scanned_names = [os.path.basename(source_path) for source_path, _ in scanner.source_paths()]
+        scanned_names = [os.path.basename(path_data.source_path) for path_data in scanner.source_paths()]
         assert scanned_names == [name_to_include]
 
     def test_can_find_python_files_in_dot(self):
         scanner = analysis.SourceScanner(["."], "py")
         actual_paths = list(scanner.source_paths())
         assert actual_paths != []
-        for python_path, _ in actual_paths:
-            actual_suffix = os.path.splitext(python_path)[1]
+        for path_data in actual_paths:
+            actual_suffix = os.path.splitext(path_data.source_path)[1]
             assert actual_suffix == ".py"
 
     def test_can_find_files_from_mixed_cloned_git_remote_url_and_local(self):
@@ -77,7 +77,8 @@ class SourceScannerTest(TempFolderTest):
         with analysis.SourceScanner([git_remote_url, PYGOUNT_SOURCE_FOLDER]) as scanner:
             actual_paths = list(scanner.source_paths())
             assert actual_paths != []
-            assert actual_paths[0][1] != actual_paths[-1][1]
+            assert actual_paths[0].source_path != actual_paths[-1].source_path
+            assert actual_paths[-1].tmp_dir is not None
 
 
 class AnalysisTest(unittest.TestCase):


### PR DESCRIPTION
When analyzing a remote git repository a temporary folder is created. The output contained the name of this temporary folder. This commit removes the temporary directory from the displayed output path. Therefore, a new dataclass called PathData is introduced to contain the source path and temporary directory information of a path.

Close #113  