### PR TITLE
#112 Agentic coding dojo, part 1

### DIFF
--- a/pygount/command.py
+++ b/pygount/command.py
@@ -9,20 +9,26 @@ import contextlib
 import logging
 import os
 import sys
+import tempfile
 
+import git
 from rich.progress import Progress
 
 import pygount
 import pygount.analysis
 import pygount.common
+import pygount.git_storage
 import pygount.write
 
 #: Valid formats for option --format.
-VALID_OUTPUT_FORMATS = ("cloc-xml", "json", "sloccount", "summary")
+VALID_OUTPUT_FORMATS = ("cloc-xml", "graph", "json", "sloccount", "summary")
 
 _DEFAULT_ENCODING = "automatic"
 _DEFAULT_OUTPUT_FORMAT = "sloccount"
 _DEFAULT_OUTPUT = "STDOUT"
+_DEFAULT_COLORS = "#0747A6, #00B8D9, #172B4D, #FF8B00, #006644, #FFC400"
+_DEFAULT_WIDTH = 1024
+_DEFAULT_HEIGHT = 768
 _DEFAULT_SOURCE_PATTERNS = os.curdir
 _DEFAULT_SUFFIXES = "*"
 
@@ -70,6 +76,7 @@ _HELP_SUFFIX = '''limit analysis on files matching any suffix in comma
 
 _OUTPUT_FORMAT_TO_WRITER_CLASS_MAP = {
     "cloc-xml": pygount.write.ClocXmlWriter,
+    "graph": pygount.write.GraphWriter,
     "json": pygount.write.JsonWriter,
     "sloccount": pygount.write.LineWriter,
     "summary": pygount.write.SummaryWriter,
@@ -121,6 +128,9 @@ class Command:
         self._output_format = _DEFAULT_OUTPUT_FORMAT
         self._source_patterns = _DEFAULT_SOURCE_PATTERNS
         self._suffixes = pygount.common.regexes_from(_DEFAULT_SUFFIXES)
+        self._colors = _DEFAULT_COLORS
+        self._width = _DEFAULT_WIDTH
+        self._height = _DEFAULT_HEIGHT
 
     def set_encodings(self, encoding, source=None):
         encoding_is_chardet = (encoding == "chardet") or (encoding.startswith("chardet;"))
@@ -154,6 +164,14 @@ class Command:
     def set_fallback_encoding(self, fallback_encoding, source=None):
         _check_encoding("fallback encoding", fallback_encoding, "automatic", source)
         self._fallback_encoding = fallback_encoding
+
+    @property
+    def colors(self):
+        return self._colors
+
+    def set_colors(self, colors, source=None):
+        assert colors is not None
+        self._colors = colors
 
     @property
     def folders_to_skip(self):
@@ -195,6 +213,13 @@ class Command:
 
     def set_has_to_merge_embedded_languages(self, has_to_merge_embedded_languages, source=None):
         self._has_to_merge_embedded_languages = bool(has_to_merge_embedded_languages)
+
+    @property
+    def height(self):
+        return self._height
+
+    def set_height(self, height, source=None):
+        self._height = height
 
     @property
     def is_verbose(self):
@@ -249,8 +274,21 @@ class Command:
         assert regexes_or_patterns_text is not None
         self._suffixes = pygount.common.regexes_from(regexes_or_patterns_text, _DEFAULT_SUFFIXES, source)
 
+    @property
+    def width(self):
+        return self._width
+
+    def set_width(self, width, source=None):
+        self._width = width
+
     def argument_parser(self):
         parser = argparse.ArgumentParser(description="count source lines of code", epilog=_HELP_EPILOG)
+        parser.add_argument(
+            "--colors",
+            metavar="COLORS",
+            default=_DEFAULT_COLORS,
+            help='comma separated list of hex codes for the most popular languages; default: "%(default)s"',
+        )
         parser.add_argument("--duplicates", "-d", action="store_true", help="analyze duplicate files")
         parser.add_argument("--encoding", "-e", default=_DEFAULT_ENCODING, help=_HELP_ENCODING)
         parser.add_argument(
@@ -283,6 +321,13 @@ class Command:
             help=_HELP_GENERATED_NAMES,
         )
         parser.add_argument(
+            "--height",
+            metavar="HEIGHT",
+            type=int,
+            default=_DEFAULT_HEIGHT,
+            help='height of the chart in pixels; default: "%(default)s"',
+        )
+        parser.add_argument(
             "--merge-embedded-languages",
             "-m",
             action="store_true",
@@ -312,6 +357,13 @@ class Command:
         )
         parser.add_argument("--verbose", "-v", action="store_true", help="explain what is being done")
         parser.add_argument("--version", action="version", version="%(prog)s " + pygount.__version__)
+        parser.add_argument(
+            "--width",
+            metavar="WIDTH",
+            type=int,
+            default=_DEFAULT_WIDTH,
+            help='width of the chart in pixels; default: "%(default)s"',
+        )
         return parser
 
     def parsed_args(self, arguments):
@@ -343,6 +395,19 @@ class Command:
                     "".encode(encoding)
                 except LookupError:
                     parser.error(f"{name} specified with --encoding must be a known Python encoding: {encoding}")
+        if args.format == "graph":
+            if (
+                len(args.source_patterns) != 1
+                or pygount.git_storage.git_remote_url_and_revision_if_any(args.source_patterns[0])[0] is None
+            ):
+                parser.error("--graph requires a single git URL as source")
+        if args.width < 600 or args.width > 32767:
+            parser.error("Value for option --width must be between 600 and 32767.")
+        if args.height < 400 or args.height > 32767:
+            parser.error("Value for option --height must be between 400 and 32767.")
+        colors = [color.strip().lstrip("#") for color in args.colors.split(",") if color.strip().lstrip("#") != ""]
+        if len(colors) < 2:
+            parser.error("At least two colors must be specified.")
         return args, default_encoding, fallback_encoding
 
     def apply_arguments(self, arguments=None):
@@ -362,9 +427,15 @@ class Command:
         self.set_output_format(args.format, "option --format")
         self.set_source_patterns(args.source_patterns, "option PATTERNS")
         self.set_suffixes(args.suffix, "option --suffix")
+        self.set_colors(args.colors, "option --colors")
+        self.set_width(args.width, "option --width")
+        self.set_height(args.height, "option --height")
 
     def execute(self):
         _log.setLevel(logging.INFO if self.is_verbose else logging.WARNING)
+        if self.output_format == "graph":
+            self._execute_graph()
+            return
         with pygount.analysis.SourceScanner(
             self.source_patterns, self.suffixes, self.folders_to_skip, self.names_to_skip
         ) as source_scanner:
@@ -399,6 +470,52 @@ class Command:
                         )
                 finally:
                     progress.stop()
+
+    def _execute_graph(self):
+        remote_url, _ = pygount.git_storage.git_remote_url_and_revision_if_any(self.source_patterns[0])
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            _log.info("cloning %s to %s", remote_url, tmp_dir)
+            repo = git.Repo.clone_from(remote_url, tmp_dir)
+            tags = sorted(repo.tags, key=lambda t: t.commit.committed_datetime)
+            if not tags:
+                _log.warning("no tags found in %s", remote_url)
+
+            writer_class = _OUTPUT_FORMAT_TO_WRITER_CLASS_MAP[self.output_format]
+            is_stdout = self.output == "STDOUT"
+            target_context_manager = (
+                contextlib.nullcontext(sys.stdout)
+                if is_stdout
+                else open(self.output, "w", encoding="utf-8", newline="")  # noqa: SIM115
+            )
+
+            with (
+                target_context_manager as target_file,
+                writer_class(target_file, colors=self.colors, width=self.width, height=self.height) as writer,
+                Progress(disable=not writer.has_to_track_progress, transient=True) as progress,
+            ):
+                tag_progress = progress.add_task("Analyzing tags", total=len(tags))
+                for tag in tags:
+                    _log.info("analyzing tag %s", tag.name)
+                    repo.git.checkout(tag.name)
+                    duplicate_pool = pygount.analysis.DuplicatePool() if not self.has_duplicates else None
+                    with pygount.analysis.SourceScanner(
+                        [tmp_dir], self.suffixes, self.folders_to_skip, self.names_to_skip
+                    ) as source_scanner:
+                        source_paths_and_groups_to_analyze = list(source_scanner.source_paths())
+                        for path_data in source_paths_and_groups_to_analyze:
+                            writer.add(
+                                pygount.analysis.SourceAnalysis.from_file(
+                                    path_data.source_path,
+                                    tag.name,
+                                    self.default_encoding,
+                                    self.fallback_encoding,
+                                    generated_regexes=self._generated_line_regexs,
+                                    generated_name_regexes=self._generated_name_regexps,
+                                    duplicate_pool=duplicate_pool,
+                                    merge_embedded_language=self.has_to_merge_embedded_languages,
+                                )
+                            )
+                    progress.advance(tag_progress)
 
 
 def pygount_command(arguments=None):

--- a/pygount/write.py
+++ b/pygount/write.py
@@ -25,7 +25,7 @@ JSON_FORMAT_VERSION = "1.1.0"
 
 
 class BaseWriter:
-    def __init__(self, target_stream):
+    def __init__(self, target_stream, **kwargs):
         self._target_stream = target_stream
         try:
             self.target_name = self._target_stream.name
@@ -71,8 +71,8 @@ class LineWriter(BaseWriter):
     Writer that simply writes a line of text for each source code.
     """
 
-    def __init__(self, target_stream):
-        super().__init__(target_stream)
+    def __init__(self, target_stream, **kwargs):
+        super().__init__(target_stream, **kwargs)
         self.has_to_track_progress = False
 
     def add(self, source_analysis):
@@ -90,8 +90,8 @@ class ClocXmlWriter(BaseWriter):
     plug-in.
     """
 
-    def __init__(self, target_stream):
-        super().__init__(target_stream)
+    def __init__(self, target_stream, **kwargs):
+        super().__init__(target_stream, **kwargs)
         self._results_element = ElementTree.Element("results")
         self._header_element = ElementTree.SubElement(self._results_element, "header")
         ElementTree.SubElement(self._header_element, "cloc_url", text="https://github.com/roskakori/pygount")
@@ -192,8 +192,8 @@ class JsonWriter(BaseWriter):
     Writer JSON output, ideal for further automatic processing.
     """
 
-    def __init__(self, target_stream):
-        super().__init__(target_stream)
+    def __init__(self, target_stream, **kwargs):
+        super().__init__(target_stream, **kwargs)
         self.source_analyses = []
 
     def add(self, source_analysis: SourceAnalysis):
@@ -262,6 +262,124 @@ class JsonWriter(BaseWriter):
             },
         }
         json.dump(json_map, self._target_stream)
+
+
+class GraphWriter(BaseWriter):
+    """
+    Writer that generates an SVG chart showing SLOC per language over git tags.
+    """
+
+    def __init__(self, target_stream, **kwargs):
+        super().__init__(target_stream, **kwargs)
+        colors_text = kwargs.get("colors", "")
+        self._colors = ["#" + c.strip().lstrip("#") for c in colors_text.split(",") if c.strip().lstrip("#")]
+        self._width = kwargs.get("width", 1024)
+        self._height = kwargs.get("height", 768)
+        self._tag_names = []
+        self._tag_to_language_sloc = {}
+        self._languages = set()
+
+    def add(self, source_analysis: SourceAnalysis):
+        super().add(source_analysis)
+        tag = source_analysis.group
+        if tag not in self._tag_to_language_sloc:
+            self._tag_to_language_sloc[tag] = {}
+            self._tag_names.append(tag)
+        lang = source_analysis.language
+        self._languages.add(lang)
+        sloc = source_analysis.code_count + source_analysis.string_count
+        self._tag_to_language_sloc[tag][lang] = self._tag_to_language_sloc[tag].get(lang, 0) + sloc
+
+    def close(self):
+        super().close()
+        if not self._tag_names:
+            return
+
+        # Sort languages by total SLOC across all tags.
+        lang_totals = {
+            lang: sum(self._tag_to_language_sloc[tag].get(lang, 0) for tag in self._tag_names)
+            for lang in self._languages
+        }
+        sorted_langs = sorted(self._languages, key=lambda l: lang_totals[l], reverse=True)
+
+        # Parameters for the chart.
+        margin_left = 80
+        margin_right = 150
+        margin_top = 50
+        margin_bottom = 80
+        chart_width = self._width - margin_left - margin_right
+        chart_height = self._height - margin_top - margin_bottom
+
+        max_sloc = 0
+        for tag in self._tag_names:
+            total = sum(self._tag_to_language_sloc[tag].values())
+            max_sloc = max(max_sloc, total)
+        if max_sloc == 0:
+            max_sloc = 1
+
+        # Start SVG.
+        svg = [
+            f'<svg width="{self._width}" height="{self._height}" xmlns="http://www.w3.org/2000/svg">',
+            '<rect width="100%" height="100%" fill="white"/>',
+        ]
+
+        # Draw axes.
+        svg.append(
+            f'<line x1="{margin_left}" y1="{margin_top}" x2="{margin_left}" y2="{self._height - margin_bottom}" stroke="black"/>'
+        )
+        svg.append(
+            f'<line x1="{margin_left}" y1="{self._height - margin_bottom}" x2="{self._width - margin_right}" y2="{self._height - margin_bottom}" stroke="black"/>'
+        )
+
+        num_tags = len(self._tag_names)
+        x_step = chart_width / (num_tags - 1) if num_tags > 1 else chart_width
+
+        # Draw stacked areas.
+        prev_y = [self._height - margin_bottom] * num_tags
+        for i, lang in enumerate(sorted_langs):
+            color = self._colors[i % len(self._colors)]
+            points = []
+            new_prev_y = []
+            for j, tag in enumerate(self._tag_names):
+                x = margin_left + j * x_step
+                sloc = self._tag_to_language_sloc[tag].get(lang, 0)
+                y = prev_y[j] - (sloc / max_sloc * chart_height)
+                points.append(f"{x},{y}")
+                new_prev_y.append(y)
+
+            # Area path.
+            path_points = points + [
+                f"{margin_left + (num_tags - 1) * x_step},{prev_y[-1]}",
+                f"{margin_left},{prev_y[0]}",
+            ]
+            svg.append(f'<polygon points="{" ".join(path_points)}" fill="{color}" opacity="0.8"/>')
+            prev_y = new_prev_y
+
+            # Legend.
+            legend_x = self._width - margin_right + 10
+            legend_y = margin_top + i * 20
+            svg.append(f'<rect x="{legend_x}" y="{legend_y}" width="15" height="15" fill="{color}"/>')
+            svg.append(
+                f'<text x="{legend_x + 20}" y="{legend_y + 12}" font-family="sans-serif" font-size="12">{lang}</text>'
+            )
+
+        # Draw tag labels.
+        for j, tag in enumerate(self._tag_names):
+            x = margin_left + j * x_step
+            svg.append(
+                f'<text x="{x}" y="{self._height - margin_bottom + 20}" font-family="sans-serif" font-size="10" text-anchor="middle" transform="rotate(45 {x},{self._height - margin_bottom + 20})">{tag}</text>'
+            )
+
+        # Y axis labels.
+        for i in range(6):
+            val = int(max_sloc * i / 5)
+            y = self._height - margin_bottom - (i / 5 * chart_height)
+            svg.append(
+                f'<text x="{margin_left - 5}" y="{y + 4}" font-family="sans-serif" font-size="10" text-anchor="end">{val}</text>'
+            )
+
+        svg.append("</svg>")
+        self._target_stream.write("\n".join(svg))
 
 
 def digit_width(line_count: int) -> int:

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -209,6 +209,8 @@ class PygountCommandTest(TempFolderTest):
 
     def test_can_write_all_output_formats(self):
         for output_format in VALID_OUTPUT_FORMATS:
+            if output_format == "graph":
+                continue
             exit_code = command.pygount_command(["--format", output_format, PYGOUNT_SOURCE_FOLDER])
             self.assertEqual(exit_code, 0)
 
@@ -227,3 +229,25 @@ class PygountCommandTest(TempFolderTest):
         file_elements = cloc_xml_root.findall("files/file[@language='HTML']")
         assert file_elements is not None
         assert len(file_elements) == 1
+
+
+class GraphCommandTest(TempFolderTest):
+    def test_fails_on_graph_without_git_url(self):
+        with pytest.raises(SystemExit) as error_info:
+            command.pygount_command(["--format", "graph", self.tests_temp_folder])
+        assert error_info.value.code == 2
+
+    def test_fails_on_invalid_width(self):
+        with pytest.raises(SystemExit) as error_info:
+            command.pygount_command(["--width", "100", self.tests_temp_folder])
+        assert error_info.value.code == 2
+
+    def test_fails_on_invalid_height(self):
+        with pytest.raises(SystemExit) as error_info:
+            command.pygount_command(["--height", "100", self.tests_temp_folder])
+        assert error_info.value.code == 2
+
+    def test_fails_on_too_few_colors(self):
+        with pytest.raises(SystemExit) as error_info:
+            command.pygount_command(["--colors", "#123456", self.tests_temp_folder])
+        assert error_info.value.code == 2

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -60,6 +60,28 @@ def test_can_compute_digit_width():
     assert write.digit_width(1000) == 4
 
 
+def test_can_write_graph():
+    source_analyses = (
+        analysis.SourceAnalysis("v1.py", "Python", "v1.0", 100, 0, 0, 0, analysis.SourceState.analyzed, None),
+        analysis.SourceAnalysis("v1.sh", "Bash", "v1.0", 50, 0, 0, 0, analysis.SourceState.analyzed, None),
+        analysis.SourceAnalysis("v2.py", "Python", "v2.0", 200, 0, 0, 0, analysis.SourceState.analyzed, None),
+    )
+    with io.StringIO() as target_stream:
+        with write.GraphWriter(target_stream, colors="#123456, #abcdef", width=800, height=600) as writer:
+            for source_analysis in source_analyses:
+                writer.add(source_analysis)
+        svg_data = target_stream.getvalue()
+        assert "<svg" in svg_data
+        assert 'width="800"' in svg_data
+        assert 'height="600"' in svg_data
+        assert "Python" in svg_data
+        assert "Bash" in svg_data
+        assert "v1.0" in svg_data
+        assert "v2.0" in svg_data
+        assert "#123456" in svg_data
+        assert "#abcdef" in svg_data
+
+
 _LINE_WORD_REGEX = re.compile(r"[\w\\.]+")  # HACK: For test assume all language names are "\w+".
 
 


### PR DESCRIPTION
The source code is this PR was solely created by Jetbrains' Junie coding agent.

The prompt used was a dump of the work-in-progress issue description of #112, which at that time read:

> ## Goals
> 
> - [ ] When a user specifies the command lines option `--format=graph`, the output is an image file showing how the SLOC changed over time for each git tag.
> - [ ] If the command line options for the source path are anything but a single git URL, pygount fails with the error:
>   > `--graph` requires a single git URL as source
> - [ ] The command line option `--colors` allows to specify the colors for the most popular languages as comma separated list of hex codes with white space and `#` being ignored. ℹ️  For example: `#123456, 789abc`
>     - [ ] The default is ❓ TBD: Use up to 6 colors that look "nice" but also alternate between bright and dark to make them easy to distinguish even for people with color deficiencies. ℹ️ For inspiration, take a look at [Atlassian's categorical colors](https://atlassian.design/foundations/color/data-visualization-color#categorical).
>     - [ ] If less than 2 colors are specified, the option is rejected with the message:
>        > At least two colors must be specified.
>     - [ ] If there are more languages then colors, the colors rotate and are re-used.
>     - [ ] If there are more colors than languages, only the required number of colors shows in the graph.
> - [ ] The chart output image format is ❓ TBD. HTML? SVG?
> - [ ] In the graph, the languages are sorted in ❓ TBD: Sort how?
> - [ ] The command line option `--width` and `--height` specify the size of the chart in ❓ TBD: pixels? dip? pt?
>     - [ ] The defaults are 1024 resp. 768.
>     - [ ] If the value is less than than 600 resp. 400 or more than 32,767, it is rejected with the message:
>       > Value for option `--xxx` must be between XXX and 32767.
> 
>       ℹ️ PNG could use sizes up to 2**31 - 1.
> - [ ] ❓ TBD: General chart layout, percentage used, maximum length of language before cut off, font to use, ...

With this, you can run

```bash
pygount --format=graph git@github.com:roskakori/pygount.git --out /tmp/pygount.svg
```
and get the following SVG:

![pygount.svg](https://github.com/user-attachments/assets/6f3267f7-f59a-4ee5-ad68-f7b4614613d3)